### PR TITLE
tags migration script

### DIFF
--- a/scripts/migrations/2013_12_05_migrate_tags/data_migration.py
+++ b/scripts/migrations/2013_12_05_migrate_tags/data_migration.py
@@ -1,0 +1,47 @@
+from taggit.models import Tag, TaggedItem
+
+
+def migrate_tag_objects(ids):
+  # tags_count_list = [(t.id, TaggedItem.objects.filter(tag=t).count()) for t in qs]
+  print "migrate %s <= %s" % (ids[0], ids[1:])
+  target = Tag.objects.get(pk=ids[0])
+  tags = ids[1:]
+  for tag in tags:
+    tag = Tag.objects.get(pk=tag)
+    objects = [item.content_object for item in tag.taggit_taggeditem_items.all()]
+    for obj in objects:
+      print "move %s on object %s to %s" % (tag.id, obj, target.id)
+      obj.tags.add(target)
+      obj.tags.remove(tag)
+    tag.delete()
+
+
+def migrate_duplicated_tags():
+  alreade_migrated = set()
+  for tag in Tag.objects.all():
+    qs = Tag.objects.filter(name=tag.name.lower())
+    ids = set()
+    if qs.count() > 1:
+      ids.add(tag.id)
+      [ids.add(t.id) for t in qs]
+      if len(ids & alreade_migrated) == 0:
+        migrate_tag_objects(list(ids))
+        [alreade_migrated.add(id) for id in ids]
+
+def lowercase_all_tags():
+    print 'lowercase_all_tags'
+    for tag in Tag.objects.all():
+      if not tag.name.islower():
+        print "'%s'  ==>  '%s'" % (tag.name, tag.name.lower())
+        tag.name = tag.name.lower()
+      tag.name = tag.name.strip()
+      if not tag.name:
+        tag.delete()
+      else:
+        tag.save()
+
+
+def run():
+  lowercase_all_tags()
+  migrate_duplicated_tags()
+


### PR DESCRIPTION
O script de migração está em `scripts/migrations/2013_12_05_migrate_tags/data_migation.py`

basta rodá-lo num shell do django, por exemplo:

```
# adiciona o script em qquer lugar do pythonpath
ln -s scripts/migrations/2013_12_05_migrate_tags/data_migation.py  mootiro_maps/apps/mig.py

fab local run.shell

>>> import mig
>>> mig.run()
..... # looong time

>>> # se tudo estiver correto, vc podera rodar `mig.run()` e dessa vez ele não devera achar nenhum duplicata nem com Uppercase.


# rm mootiro_maps/apps/mig.py só pra limpar

```

a parte de interface já foi feita via colaboração do pessoal da UNB anteriormente,  =D
